### PR TITLE
Fix issue 41, install from PyPI (whl & tar.gz)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest==3.9.2
 python-coveralls==2.9.1
 pytest-flake8==1.0.2
 flake8==3.6.0
+wheel==0.33.4

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,21 @@
-import os.path
 import setuptools
 
 with open('README.md', 'r') as fh:
     long_description = fh.read()
 
-with open(os.path.join(os.path.dirname(__file__), 'requirements.txt')) as fh:
-    install_requires = fh.readlines()
 
-with open(os.path.join(os.path.dirname(__file__), 'requirements-dev.txt')) as fh:
-    tests_require = fh.readlines()
+install_requires = ['requests==2.20.0', ]
+
+tests_require = [
+    'responses==0.10.1',
+    'coverage==4.0.3',
+    'pytest==3.9.2',
+    'python-coveralls==2.9.1',
+    'pytest-flake8==1.0.2',
+    'flake8==3.6.0',
+    'wheel==0.33.4',
+]
+
 
 setuptools.setup(
     name='SalesforcePy',
@@ -29,4 +36,5 @@ setuptools.setup(
     zip_safe=False,
     install_requires=install_requires,
     setup_requires=['pytest-runner'],
-    tests_require=tests_require)
+    tests_require=tests_require
+)


### PR DESCRIPTION
This PR allows to install the package directly from PyPI (or from *.whl, *.tar.gz) using ```pip install SalesforcePy``` command.

Testing done:

Build whl:
```
(venv37) $ python setup.py bdist_wheel
running bdist_wheel
running build
running build_py
installing to build/bdist.macosx-10.13-x86_64/wheel
running install
running install_lib
creating build/bdist.macosx-10.13-x86_64/wheel
creating build/bdist.macosx-10.13-x86_64/wheel/SalesforcePy
copying build/lib/SalesforcePy/chatter.py -> build/bdist.macosx-10.13-x86_64/wheel/SalesforcePy
copying build/lib/SalesforcePy/wave.py -> build/bdist.macosx-10.13-x86_64/wheel/SalesforcePy
copying build/lib/SalesforcePy/__init__.py -> build/bdist.macosx-10.13-x86_64/wheel/SalesforcePy
copying build/lib/SalesforcePy/jobs.py -> build/bdist.macosx-10.13-x86_64/wheel/SalesforcePy
copying build/lib/SalesforcePy/commons.py -> build/bdist.macosx-10.13-x86_64/wheel/SalesforcePy
copying build/lib/SalesforcePy/sfdc.py -> build/bdist.macosx-10.13-x86_64/wheel/SalesforcePy
running install_egg_info
running egg_info
writing SalesforcePy.egg-info/PKG-INFO
writing dependency_links to SalesforcePy.egg-info/dependency_links.txt
writing requirements to SalesforcePy.egg-info/requires.txt
writing top-level names to SalesforcePy.egg-info/top_level.txt
reading manifest file 'SalesforcePy.egg-info/SOURCES.txt'
writing manifest file 'SalesforcePy.egg-info/SOURCES.txt'
Copying SalesforcePy.egg-info to build/bdist.macosx-10.13-x86_64/wheel/SalesforcePy-1.1.2-py3.7.egg-info
running install_scripts
adding license file "LICENSE" (matched pattern "LICEN[CS]E*")
creating build/bdist.macosx-10.13-x86_64/wheel/SalesforcePy-1.1.2.dist-info/WHEEL
creating 'dist/SalesforcePy-1.1.2-py3-none-any.whl' and adding 'build/bdist.macosx-10.13-x86_64/wheel' to it
adding 'SalesforcePy/__init__.py'
adding 'SalesforcePy/chatter.py'
adding 'SalesforcePy/commons.py'
adding 'SalesforcePy/jobs.py'
adding 'SalesforcePy/sfdc.py'
adding 'SalesforcePy/wave.py'
adding 'SalesforcePy-1.1.2.dist-info/LICENSE'
adding 'SalesforcePy-1.1.2.dist-info/METADATA'
adding 'SalesforcePy-1.1.2.dist-info/WHEEL'
adding 'SalesforcePy-1.1.2.dist-info/top_level.txt'
adding 'SalesforcePy-1.1.2.dist-info/RECORD'
removing build/bdist.macosx-10.13-x86_64/wheel
```

build sdist:
```
(venv37) $ python setup.py sdist
running sdist
running egg_info
writing SalesforcePy.egg-info/PKG-INFO
writing dependency_links to SalesforcePy.egg-info/dependency_links.txt
writing requirements to SalesforcePy.egg-info/requires.txt
writing top-level names to SalesforcePy.egg-info/top_level.txt
reading manifest file 'SalesforcePy.egg-info/SOURCES.txt'
writing manifest file 'SalesforcePy.egg-info/SOURCES.txt'
running check
creating SalesforcePy-1.1.2
creating SalesforcePy-1.1.2/SalesforcePy
creating SalesforcePy-1.1.2/SalesforcePy.egg-info
copying files to SalesforcePy-1.1.2...
copying README.md -> SalesforcePy-1.1.2
copying setup.cfg -> SalesforcePy-1.1.2
copying setup.py -> SalesforcePy-1.1.2
copying SalesforcePy/__init__.py -> SalesforcePy-1.1.2/SalesforcePy
copying SalesforcePy/chatter.py -> SalesforcePy-1.1.2/SalesforcePy
copying SalesforcePy/commons.py -> SalesforcePy-1.1.2/SalesforcePy
copying SalesforcePy/jobs.py -> SalesforcePy-1.1.2/SalesforcePy
copying SalesforcePy/sfdc.py -> SalesforcePy-1.1.2/SalesforcePy
copying SalesforcePy/wave.py -> SalesforcePy-1.1.2/SalesforcePy
copying SalesforcePy.egg-info/PKG-INFO -> SalesforcePy-1.1.2/SalesforcePy.egg-info
copying SalesforcePy.egg-info/SOURCES.txt -> SalesforcePy-1.1.2/SalesforcePy.egg-info
copying SalesforcePy.egg-info/dependency_links.txt -> SalesforcePy-1.1.2/SalesforcePy.egg-info
copying SalesforcePy.egg-info/not-zip-safe -> SalesforcePy-1.1.2/SalesforcePy.egg-info
copying SalesforcePy.egg-info/requires.txt -> SalesforcePy-1.1.2/SalesforcePy.egg-info
copying SalesforcePy.egg-info/top_level.txt -> SalesforcePy-1.1.2/SalesforcePy.egg-info
Writing SalesforcePy-1.1.2/setup.cfg
Creating tar archive
removing 'SalesforcePy-1.1.2' (and everything under it)
```

result:
```
(venv37) $ ls -al dist/
total 72
-rw-r--r--  15 Aug 14:04 SalesforcePy-1.1.2-py3-none-any.whl
-rw-r--r--  15 Aug 14:04 SalesforcePy-1.1.2.tar.gz
```


Create and activate separate venv (Python3.7):
```
$ python3 -m venv venvsfdc
$ source venvsfdc/bin/activate
(venvsfdc) $ pip install -U pip
Collecting pip
  Using cached https://files.pythonhosted.org/packages/8d/07/f7d7ced2f97ca3098c16565efbe6b15fafcba53e8d9bdb431e09140514b0/pip-19.2.2-py2.py3-none-any.whl
Installing collected packages: pip
  Found existing installation: pip 19.0.3
    Uninstalling pip-19.0.3:
      Successfully uninstalled pip-19.0.3
Successfully installed pip-19.2.2
```

Install SalesforcePy from whl:
```
(venvsfdc) $ pip install ~/projects/SalesforcePy/dist/SalesforcePy-1.1.2-py3-none-any.whl
Processing /Users/jjarosz/projects/SalesforcePy/dist/SalesforcePy-1.1.2-py3-none-any.whl
Collecting requests==2.20.0 (from SalesforcePy==1.1.2)
  Using cached https://files.pythonhosted.org/packages/f1/ca/10332a30cb25b627192b4ea272c351bce3ca1091e541245cccbace6051d8/requests-2.20.0-py2.py3-none-any.whl
Collecting certifi>=2017.4.17 (from requests==2.20.0->SalesforcePy==1.1.2)
  Using cached https://files.pythonhosted.org/packages/69/1b/b853c7a9d4f6a6d00749e94eb6f3a041e342a885b87340b79c1ef73e3a78/certifi-2019.6.16-py2.py3-none-any.whl
Collecting urllib3<1.25,>=1.21.1 (from requests==2.20.0->SalesforcePy==1.1.2)
  Using cached https://files.pythonhosted.org/packages/01/11/525b02e4acc0c747de8b6ccdab376331597c569c42ea66ab0a1dbd36eca2/urllib3-1.24.3-py2.py3-none-any.whl
Collecting chardet<3.1.0,>=3.0.2 (from requests==2.20.0->SalesforcePy==1.1.2)
  Using cached https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl
Collecting idna<2.8,>=2.5 (from requests==2.20.0->SalesforcePy==1.1.2)
  Using cached https://files.pythonhosted.org/packages/4b/2a/0276479a4b3caeb8a8c1af2f8e4355746a97fab05a372e4a2c6a6b876165/idna-2.7-py2.py3-none-any.whl
Installing collected packages: certifi, urllib3, chardet, idna, requests, SalesforcePy
Successfully installed SalesforcePy-1.1.2 certifi-2019.6.16 chardet-3.0.4 idna-2.7 requests-2.20.0 urllib3-1.24.3
```
test import from REPL:
```python
(venvsfdc) $ python
Python 3.7.4 (default, Jul  9 2019, 18:15:00)
[Clang 10.0.0 (clang-1000.11.45.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import SalesforcePy as sfdc
>>> help(sfdc)

Help on package SalesforcePy:

NAME
    SalesforcePy

PACKAGE CONTENTS
    chatter
    commons
    jobs
    sfdc
    wave

DATA
    absolute_import = _Feature((2, 5, 0, 'alpha', 1), (3, 0, 0, 'alpha', 0...
    name = 'SalesforcePy'

FILE
    /Users/jjarosz/venvs/venvsfdc/lib/python3.7/site-packages/SalesforcePy/__init__.py
```


Run tests:

```
(venv37) $ python setup.py test
running pytest
Searching for requests==2.20.0
Best match: requests 2.20.0
Processing requests-2.20.0-py3.7.egg

Using /Users/jjarosz/projects/SalesforcePy/.eggs/requests-2.20.0-py3.7.egg
Searching for urllib3<1.25,>=1.21.1
Best match: urllib3 1.24.3
Processing urllib3-1.24.3-py3.7.egg

Using /Users/jjarosz/projects/SalesforcePy/.eggs/urllib3-1.24.3-py3.7.egg
Searching for idna<2.8,>=2.5
Best match: idna 2.7
Processing idna-2.7-py3.7.egg

Using /Users/jjarosz/projects/SalesforcePy/.eggs/idna-2.7-py3.7.egg
running egg_info
writing SalesforcePy.egg-info/PKG-INFO
writing dependency_links to SalesforcePy.egg-info/dependency_links.txt
writing requirements to SalesforcePy.egg-info/requires.txt
writing top-level names to SalesforcePy.egg-info/top_level.txt
reading manifest file 'SalesforcePy.egg-info/SOURCES.txt'
writing manifest file 'SalesforcePy.egg-info/SOURCES.txt'
running build_ext
============================================================================= test session starts ==============================================================================
platform darwin -- Python 3.7.4, pytest-3.9.2, py-1.8.0, pluggy-0.12.0
rootdir: /Users/jjarosz/projects/SalesforcePy, inifile: setup.cfg
plugins: flake8-1.0.2
collected 95 items


setup.py s                                                                                                                                                               [  1%]
SalesforcePy/__init__.py s                                                                                                                                               [  2%]
SalesforcePy/chatter.py s                                                                                                                                                [  3%]
SalesforcePy/commons.py s                                                                                                                                                [  4%]
SalesforcePy/jobs.py s                                                                                                                                                   [  5%]
SalesforcePy/sfdc.py s                                                                                                                                                   [  6%]
SalesforcePy/wave.py s                                                                                                                                                   [  7%]
docs/conf.py s                                                                                                                                                           [  8%]
tests/test_api_version.py s.....                                                                                                                                         [ 14%]
tests/test_approvals.py s....                                                                                                                                            [ 20%]
tests/test_chatter.py s..                                                                                                                                                [ 23%]
tests/test_client.py s..........                                                                                                                                         [ 34%]
tests/test_execute_anonymous.py s...                                                                                                                                     [ 38%]
tests/test_jobs.py s.........                                                                                                                                            [ 49%]
tests/test_login.py s....                                                                                                                                                [ 54%]
tests/test_logout.py s...                                                                                                                                                [ 58%]
tests/test_query.py s..                                                                                                                                                  [ 62%]
tests/test_query_more.py s...                                                                                                                                            [ 66%]
tests/test_search.py s..                                                                                                                                                 [ 69%]
tests/test_sobjects.py s......................                                                                                                                           [ 93%]
tests/test_wave.py s....                                                                                                                                                 [ 98%]
tests/testutil.py s                                                                                                                                                      [100%]

=============================================================================== warnings summary ===============================================================================
/Users/jjarosz/projects/SalesforcePy/venv37/lib/python3.7/site-packages/responses.py:137: DeprecationWarning: `formatargspec` is deprecated since Python 3.5. Use `signature` an
d the `Signature` object directly
  signature = inspect.formatargspec(args, a, kw, defaults)

...

/Users/jjarosz/projects/SalesforcePy/venv37/lib/python3.7/site-packages/responses.py:141: DeprecationWarning: `formatargspec` is deprecated since Python 3.5. Use `signature` an
d the `Signature` object directly
  callargs = inspect.formatargspec(args, a, kw, None)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================================================= 73 passed, 22 skipped, 138 warnings in 1.27 seconds ==============================================================

```

Note:

I haven't updated docs. Please review the PR. If all is ok I can update documents (.rst files) and add info regarding building and installing from PyPI. I have run tests on mac, python 3.7.


