### PR TITLE
General python 3.7 maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 .Python
 env/
 .env/
+.venv/
 build/
 develop-eggs/
 dist/
@@ -25,6 +26,7 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+docs/_build/
 
 .idea/
 htmlcov/

--- a/SalesforcePy/sfdc.py
+++ b/SalesforcePy/sfdc.py
@@ -85,7 +85,7 @@ class Client(object):
                 - `*login_url` (`string`) - Salesforce login URL.
                 - `*client_id` (`string`) - Salesforce client ID.
                 - `*client_secret` (`string`) - Salesforce client secret.
-                - `\**kwargs` - kwargs (see below)
+                - `**kwargs` - kwargs (see below)
 
             :Keyword Arguments:
                 * *protocol* (`string`) --
@@ -1028,7 +1028,7 @@ def client(username, password, client_id, client_secret, **kwargs):
               Salesforce client ID.
             `*client_secret` (`string`)
               Salesforce client secret.
-            `\**kwargs`
+            `**kwargs`
               kwargs (see below)
 
         :Keyword Arguments:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,8 @@
-responses==0.10.1
+responses>=0.10.3
 coverage==4.0.3
-pytest==3.9.2
+pytest>=3.10.1
 python-coveralls==2.9.1
 pytest-flake8==1.0.2
 flake8==3.6.0
+sphinx==2.2.0
+sphinx_rtd_theme==0.4.3


### PR DESCRIPTION
- Fixed deprecation warnings generated during test runs under 3.7. Mostly involving bumping dependency versions.
- Added .venv/ and docs/_build/ to .gitignore
- Added sphinx to dev dependencies. I was a little surprised that the build binaries weren't available when running the `make html` target