### PR TITLE
Unpin requests from setup.install_requires

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.20.0
+requests==2.21.0

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.md', 'r') as fh:
     long_description = fh.read()
 
 
-install_requires = ['requests==2.20.0', ]
+install_requires = ['requests>=2.21.0', ]
 
 tests_require = [
     'responses==0.10.1',


### PR DESCRIPTION
`requests==2.20.0` is really outdated by now ([2018-11-08](https://requests.readthedocs.io/en/master/community/updates/#id5)), and the explicit pin in `setup.py` is starting to cause conflicts with other libraries that use more recent versions/also dropped Python 3.4 support.

this change would remove support for Python 3.4, but that has already been removed in https://github.com/forcedotcom/SalesforcePy/pull/45.