### PR TITLE
Fix "is" with a literal

### DIFF
--- a/SalesforcePy/sfdc.py
+++ b/SalesforcePy/sfdc.py
@@ -534,7 +534,7 @@ class QueryMore(commons.BaseRequest):
 
         (last, results) = (
             dict(),
-            list() if len(args) is 0 else args[0],
+            list() if len(args) == 0 else args[0],
         )
 
         len_results = len(results)


### PR DESCRIPTION
See https://adamj.eu/tech/2020/01/21/why-does-python-3-8-syntaxwarning-for-is-literal/