### PR TITLE
Fix version not being passed through in query_more

### DIFF
--- a/SalesforcePy/commons.py
+++ b/SalesforcePy/commons.py
@@ -253,17 +253,6 @@ class BaseRequest(object):
         finally:
             return response
 
-    def set_proxies(self, proxies):
-        """ Sets `proxies` for this class.
-
-        :param proxies: A dict containing proxies to use (see: # noqa
-        `Proxies <http://docs.python-requests.org/en/master/user/advanced/#proxies)>`_ # noqa
-        in the python-requests.org guide.
-
-        :type: dict
-        """
-        self.proxies = proxies
-
 
 class OAuthRequest(BaseRequest):
     """ Base class for all OAuth request objects

--- a/SalesforcePy/sfdc.py
+++ b/SalesforcePy/sfdc.py
@@ -540,8 +540,8 @@ class QueryMore(commons.BaseRequest):
         len_results = len(results)
 
         if len_results == 0:
-            q = Query(self.session_id, self.instance_url, self.query_string)
-            q.set_proxies(self.proxies)
+            q = Query(self.session_id, self.instance_url, self.query_string,
+                      proxies=self.proxies, version=self.api_version)
             response = q.request()
             results.append(response)
             last = response

--- a/tests/test_query_more.py
+++ b/tests/test_query_more.py
@@ -1,5 +1,7 @@
-import testutil
 import responses
+
+import SalesforcePy as sfdc
+import testutil
 
 
 @responses.activate
@@ -10,6 +12,24 @@ def test_query_more_singlebatch():
     client = testutil.get_client()
     query_result = client.query_more("SELECT Id, Name FROM Account LIMIT 10")
     assert query_result[0][0] == testutil.mock_responses["query_response_200"]["body"]
+    assert query_result[0][0].get("done")
+
+
+@responses.activate
+def test_query_more_singlebatch_kwargs():
+    testutil.add_response("login_response_200")
+    testutil.add_response("query_response_200_version_40")
+    client = sfdc.client(
+        username=testutil.username,
+        password=testutil.password,
+        client_id=testutil.client_id,
+        client_secret=testutil.client_secret,
+        login_url=testutil.login_url,
+        version="40.0",
+    )
+    client.login()
+    query_result = client.query_more("SELECT Id, Name FROM Account LIMIT 10")
+    assert query_result[0][0] == testutil.mock_responses["query_response_200_version_40"]["body"]
     assert query_result[0][0].get("done")
 
 


### PR DESCRIPTION
And replace `set_proxies` by also passing `proxies` in the `Query` constructor, since `**kwargs` will pick that. Also, `q.proxies = self.proxies` could have been used, so `set_proxies` is more than redundant.