### PR TITLE
OAuth2 device flow implementation

### DIFF
--- a/SalesforcePy/device_flow.py
+++ b/SalesforcePy/device_flow.py
@@ -4,8 +4,57 @@ from ..commons import OAuthRequest
 class AuthNRequest(OAuthRequest):
     """ OAuth device flow authentication request implementation
     """
-    def __init__(self, client_id, **kwargs):
+    def __init__(self, client_id, device_code, **kwargs):
         super(AuthNRequest, self).__init__(None, None, **kwargs)
+        self.login_url = kwargs.get('login_url', 'login.salesforce.com')
+        self.client_id = client_id
+        self.device_code = device_code
+        self.http_method = 'POST'
+        self.service = '/services/oauth2/token'
+        self.headers = {'Content-Type': 'application/x-www-form-urlencoded', 'Host': self.login_url}
+        self.payload = self.get_payload()
+
+    def get_payload(self):
+        """ Returns the payload dict to be used in the request.
+
+        :return: OAuth2 request body required to obtain code.
+        :rtype: dict
+        """
+
+        return {
+            'grant_type': 'device',
+            'client_id': self.client_id,
+            'code': self.device_code
+        }
+    
+    def request(self):
+        """ Gets the result of `super` for this method, then assigns the `access_token` to `session_id`.
+        Returns request response.
+
+          :return: Response dict
+          :rtype: dict
+        """
+        response = super(AuthNRequest, self).request()
+        if response is not None:
+            if 'access_token' in response:
+                self.session_id = response['access_token']
+            return response
+
+    def get_session_id(self):
+        """ Returns the session ID obtained if the login request was successful
+
+          :return: Session ID
+          :rtype: string
+        """
+
+        return self.session_id
+
+
+class AuthZRequest(OAuthRequest):
+    """ OAuth device flow authorisation request implementation
+    """
+    def __init__(self, client_id, **kwargs):
+        super(AuthZRequest, self).__init__(None, None, **kwargs)
 
         self.login_url = kwargs.get('login_url', 'login.salesforce.com')
         self.client_id = client_id
@@ -35,57 +84,8 @@ class AuthNRequest(OAuthRequest):
         :return: Response dict
         :rtype: dict
         """
-        response = super(AuthNRequest, self).request()
+        response = super(AuthZRequest, self).request()
         if response is not None:
             if 'device_code' in response:
                 self.device_code = response['device_code']
             return response
-
-
-class AuthZRequest(OAuthRequest):
-    """ OAuth device flow authorization request implementation
-    """
-    def __init__(self, client_id, device_code, **kwargs):
-        super(AuthZRequest, self).__init__(None, None, **kwargs)
-        self.login_url = kwargs.get('login_url', 'login.salesforce.com')
-        self.client_id = client_id
-        self.device_code = device_code
-        self.http_method = 'POST'
-        self.service = '/services/oauth2/token'
-        self.headers = {'Content-Type': 'application/x-www-form-urlencoded', 'Host': self.login_url}
-        self.payload = self.get_payload()
-
-    def get_payload(self):
-        """ Returns the payload dict to be used in the request.
-
-        :return: OAuth2 request body required to obtain code.
-        :rtype: dict
-        """
-
-        return {
-            'grant_type': 'device',
-            'client_id': self.client_id,
-            'code': self.device_code
-        }
-    
-    def request(self):
-        """ Gets the result of `super` for this method, then assigns the `access_token` to `session_id`.
-        Returns request response.
-
-          :return: Response dict
-          :rtype: dict
-        """
-        response = super(AuthZRequest, self).request()
-        if response is not None:
-            if 'access_token' in response:
-                self.session_id = response['access_token']
-            return response
-
-    def get_session_id(self):
-        """ Returns the session ID obtained if the login request was successful
-
-          :return: Session ID
-          :rtype: string
-        """
-
-        return self.session_id

--- a/SalesforcePy/device_flow.py
+++ b/SalesforcePy/device_flow.py
@@ -1,4 +1,4 @@
-from ..commons import OAuthRequest
+from .commons import OAuthRequest
 
 
 class AuthNRequest(OAuthRequest):
@@ -11,7 +11,7 @@ class AuthNRequest(OAuthRequest):
         self.device_code = device_code
         self.http_method = 'POST'
         self.service = '/services/oauth2/token'
-        self.headers = {'Content-Type': 'application/x-www-form-urlencoded', 'Host': self.login_url}
+        self.headers = {'Content-Type': 'application/x-www-form-urlencoded', 'Host': self.login_url} # 'orgfarm-f3cf690995-dev-ed.develop.my.salesforce.com'
         self.payload = self.get_payload()
 
     def get_payload(self):
@@ -62,6 +62,7 @@ class AuthZRequest(OAuthRequest):
         self.http_method = 'POST'
         self.service = '/services/oauth2/token'
         self.headers = {'Content-Type': 'application/x-www-form-urlencoded', 'Host': self.login_url}
+        self.scope = kwargs.get('scope')
         self.payload = self.get_payload()
 
     def get_payload(self):
@@ -71,11 +72,15 @@ class AuthZRequest(OAuthRequest):
         :rtype: dict
         """
 
-        return {
-            'response_type': 'device_flow',
-            'client_id': self.client_id,
-            'scope': 'api'
+        payload = {
+            'response_type': 'device_code',
+            'client_id': self.client_id
         }
+
+        if self.scope is not None:
+            payload['scope'] = self.scope
+
+        return payload
 
     def request(self):
         """ Gets the result of `super` for this method, then assigns the `device_code`.

--- a/SalesforcePy/device_flow.py
+++ b/SalesforcePy/device_flow.py
@@ -1,0 +1,91 @@
+from ..commons import OAuthRequest
+
+
+class AuthNRequest(OAuthRequest):
+    """ OAuth device flow authentication request implementation
+    """
+    def __init__(self, client_id, **kwargs):
+        super(AuthNRequest, self).__init__(None, None, **kwargs)
+
+        self.login_url = kwargs.get('login_url', 'login.salesforce.com')
+        self.client_id = client_id
+        self.device_code = None
+        self.http_method = 'POST'
+        self.service = '/services/oauth2/token'
+        self.headers = {'Content-Type': 'application/x-www-form-urlencoded', 'Host': self.login_url}
+        self.payload = self.get_payload()
+
+    def get_payload(self):
+        """ Returns the payload dict to be used in the request.
+
+        :return: OAuth2 request body required to obtain code.
+        :rtype: dict
+        """
+
+        return {
+            'response_type': 'device_flow',
+            'client_id': self.client_id,
+            'scope': 'api'
+        }
+
+    def request(self):
+        """ Gets the result of `super` for this method, then assigns the `device_code`.
+        Returns request response.
+
+        :return: Response dict
+        :rtype: dict
+        """
+        response = super(AuthNRequest, self).request()
+        if response is not None:
+            if 'device_code' in response:
+                self.device_code = response['device_code']
+            return response
+
+
+class AuthZRequest(OAuthRequest):
+    """ OAuth device flow authorization request implementation
+    """
+    def __init__(self, client_id, device_code, **kwargs):
+        super(AuthZRequest, self).__init__(None, None, **kwargs)
+        self.login_url = kwargs.get('login_url', 'login.salesforce.com')
+        self.client_id = client_id
+        self.device_code = device_code
+        self.http_method = 'POST'
+        self.service = '/services/oauth2/token'
+        self.headers = {'Content-Type': 'application/x-www-form-urlencoded', 'Host': self.login_url}
+        self.payload = self.get_payload()
+
+    def get_payload(self):
+        """ Returns the payload dict to be used in the request.
+
+        :return: OAuth2 request body required to obtain code.
+        :rtype: dict
+        """
+
+        return {
+            'grant_type': 'device',
+            'client_id': self.client_id,
+            'code': self.device_code
+        }
+    
+    def request(self):
+        """ Gets the result of `super` for this method, then assigns the `access_token` to `session_id`.
+        Returns request response.
+
+          :return: Response dict
+          :rtype: dict
+        """
+        response = super(AuthZRequest, self).request()
+        if response is not None:
+            if 'access_token' in response:
+                self.session_id = response['access_token']
+            return response
+
+    def get_session_id(self):
+        """ Returns the session ID obtained if the login request was successful
+
+          :return: Session ID
+          :rtype: string
+        """
+
+        return self.session_id

--- a/SalesforcePy/sfdc.py
+++ b/SalesforcePy/sfdc.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import
 
 from . import chatter
 from . import commons
+from . import device_flow
 from . import einstein
 from . import jobs
 from . import wave
@@ -190,6 +191,28 @@ class Client(object):
             self.set_api_version()
 
         return req, login_response
+
+    @commons.kwarg_adder
+    def login_via_device_flow(self, **kwargs):
+        """
+        Performs OAuth device flow end-to-end and returns final authorization response if successful. Raises `SFDCRequestException` otherwise.
+
+        :param: **kwargs: kwargs
+        :type: **kwargs: dict
+        :return: Authorization response
+        :rtype: (dict, device_flow.AuthZRequest)
+        """
+        device_code_authorization = device_flow.AuthNRequest(self.client_id, **kwargs)
+        
+        # Handle and raise AuthN errors
+        
+        device_code = device_code_authorization[1].device_code
+
+        # TODO: Poll AuthZ using `device_flow.AuthZRequest(self.client_id, device_code, **kwargs)`
+        # TODO: Handle and raise AuthZ errors
+
+        pass
+
 
     @commons.kwarg_adder
     def set_api_version(self, **kwargs):

--- a/SalesforcePy/sfdc.py
+++ b/SalesforcePy/sfdc.py
@@ -240,11 +240,11 @@ class Client(object):
                     on_authenticate(authn_response, device_code_authentication)
                     return next(False)
                 
-            device_flow_login = next(True)
+            next(True)
             
             self.set_api_version()
 
-            return device_flow_login
+            return self
 
     @commons.kwarg_adder
     def set_api_version(self, **kwargs):

--- a/SalesforcePy/sfdc.py
+++ b/SalesforcePy/sfdc.py
@@ -195,21 +195,21 @@ class Client(object):
     @commons.kwarg_adder
     def login_via_device_flow(self, **kwargs):
         """
-        Performs OAuth device flow end-to-end and returns final authorization response if successful. Raises `SFDCRequestException` otherwise.
+        Performs OAuth device flow end-to-end and returns final authentication response if successful. Raises `SFDCRequestException` otherwise.
 
         :param: **kwargs: kwargs
         :type: **kwargs: dict
-        :return: Authorization response
-        :rtype: (dict, device_flow.AuthZRequest)
+        :return: Authentication response
+        :rtype: (dict, device_flow.AuthNRequest)
         """
-        device_code_authorization = device_flow.AuthNRequest(self.client_id, **kwargs)
+        device_code_authorization = device_flow.AuthZRequest(self.client_id, **kwargs)
         
-        # Handle and raise AuthN errors
+        # Handle and raise AuthZ errors
         
         device_code = device_code_authorization[1].device_code
 
-        # TODO: Poll AuthZ using `device_flow.AuthZRequest(self.client_id, device_code, **kwargs)`
-        # TODO: Handle and raise AuthZ errors
+        # TODO: Poll AuthN using `device_flow.AuthNRequest(self.client_id, device_code, **kwargs)`
+        # TODO: Handle and raise AuthN errors
 
         pass
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ tests_require = [
 
 setuptools.setup(
     name='SalesforcePy',
-    version='2.1.0',
+    version='2.2.0',
     description='An absurdly simple package for making Salesforce Rest API requests',
     url='https://github.com/forcedotcom/SalesforcePy',
     author='Aaron Caffrey',

--- a/tests/fixtures/device_code_authorization_response_200.json
+++ b/tests/fixtures/device_code_authorization_response_200.json
@@ -1,0 +1,12 @@
+{
+    "content_type": "application/x-www-form-urlencoded",
+    "method": "POST",
+    "url": "https://login.salesforce.com/services/oauth2/token",
+    "status_code": 200,
+    "body": {
+        "user_code":"X1D9SEET",
+        "device_code":"M01WRzlQaFI2ZzZCN3BzN1RUSTRjUDdNcHBnM2w3dHUuTVJBWVVMeVZxY21BOWhHTHBIaWlTLlE3ck85eWpsbWZmaUJVTTZ0RnBZQWxYRWtSakhiOTsxMC4yMi4zNC45MjsxNDc3Njc0NDg3NTA1O1gxRDlTRUVU",
+        "interval": 5,
+        "verification_uri": "https://login.salesforce.com/setup/connect"
+    }
+}

--- a/tests/fixtures/poll_device_code_authentication_response_200.json
+++ b/tests/fixtures/poll_device_code_authentication_response_200.json
@@ -1,0 +1,16 @@
+{
+    "content_type": "application/x-www-form-urlencoded",
+    "method": "POST",
+    "url": "https://login.salesforce.com/services/oauth2/token",
+    "status_code": 200,
+    "body": {
+        "access_token": "00DD00000008Uw2!ARkAQGppKf6n.VwG.EnFSvi731qWh.7vKfaJjL7h49yutIC84gAsxMrqcE81GjpTjQbDLkytl2ZwosNbIJwUS0X8ahiILj3e",
+        "refresh_token": "your token here",
+        "signature": "hJuYICd2IHsjyTcFqTYiOr8THmgDmrcjgWaMp13X6dY=",
+        "scope": "api",
+        "instance_url": "https://eu11.salesforce.com",
+        "id": "https://login.salesforce.com/id/00DD00000008Uw2MAE/005D0000001cAGmIAM",
+        "token_type": "Bearer",
+        "issued_at": "1477674717112"
+    }
+}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,28 +5,6 @@ import SalesforcePy as sfdc
 import testutil
 
 
-def test_client_no_username_negative():
-    with pytest.raises(ValueError) as e:
-        sfdc.client(
-            username=None,
-            password=testutil.password,
-            client_id=testutil.client_id,
-            client_secret=testutil.client_secret
-        )
-        assert "`username` cannot be None" in str(e.value)
-
-
-def test_client_no_password_negative():
-    with pytest.raises(ValueError) as e:
-        sfdc.client(
-            username=testutil.username,
-            password=None,
-            client_id=testutil.client_id,
-            client_secret=testutil.client_secret
-        )
-        assert "`password` cannot be None" in str(e.value)
-
-
 @responses.activate
 def test_context_manager():
 

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -26,6 +26,52 @@ def test_login_via_client():
 
 
 @responses.activate
+def test_login_via_device_flow():
+    testutil.add_response("device_code_authorization_response_200")
+    testutil.add_response("poll_device_code_authentication_response_200")
+    client = sfdc.client(
+        client_id=testutil.client_id
+    )
+    client.debug(level=logging.INFO)
+    
+    with client.login_via_device_flow() as device_code_authentication:
+        assert device_code_authentication[0] == testutil.mock_responses["poll_device_code_authentication_response_200"]["body"]
+        assert device_code_authentication[1].status == 200
+
+
+# TODO: Consider moving the following commented cases into file covering `device_flow`
+# @responses.activate
+# def test_get_device_code_authorization():
+#     testutil.add_response("device_code_authorization_response_200")
+#     client = sfdc.client(
+#         client_id=testutil.client_id
+#     )
+#     client.debug(level=logging.INFO)
+#     device_code_authorization = client.get_device_code_authorization()
+#     assert device_code_authorization[0] == testutil.mock_responses["device_code_authorization_response_200"]["body"]
+#     assert device_code_authorization[1].status == 200
+
+
+# @responses.activate
+# def test_poll_device_code_authentication():
+#     testutil.add_response("device_code_authorization_response_200")
+#     testutil.add_response("poll_device_code_authentication_response_200")
+#     client = sfdc.client(
+#         client_id=testutil.client_id
+#     )
+#     client.debug(level=logging.INFO)
+#     device_code_authorization = client.get_device_code_authorization()
+
+#     assert device_code_authorization[1].status == 200
+
+#     device_code = device_code_authorization[0]["device_code"]
+#     device_code_authentication = client.poll_device_code_authentication(device_code)
+    
+#     assert device_code_authentication[0] == testutil.mock_responses["poll_device_code_authentication_response_200"]["body"]
+#     assert device_code_authentication[1].status == 200
+
+
+@responses.activate
 def test_login_via_client_with_proxies():
     testutil.add_response("login_response_200")
     testutil.add_response("api_version_response_200")


### PR DESCRIPTION
Introducing support for [Device Flow](https://help.salesforce.com/s/articleView?id=xcloud.remoteaccess_oauth_device_flow.htm&type=5). 

## Example implementation
```
import SalesforcePy as sfdc
import json

def on_authorize(res, authz):
    # Add any required logic to perform on authorization response here
    pass

def on_authenticate(res, authz):
    # Raise an exception if the response was any error other than pending authorization, otherwise return.
    if authz.status != 200 and res.get("error") != "authorization_pending":
        raise Exception(json.dumps(res))
    else:
        return

client = sfdc.client(None, None, "<client id here>")

# Note that `on_authorize` and `on_authenticate` handlers are optional but highly recommended, especially
# to ensure authn polling fails out appropriately.
with client.login_via_device_flow(on_authorize=on_authorize, on_authenticate=on_authenticate) as c:
    account = c.query('SELECT Id FROM Account LIMIT 1')
```